### PR TITLE
refactor: rework FirebaseCore -> Firebase

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -10,7 +10,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final FirebaseApp app = await FirebaseCore.instance.initializeApp(
+  final FirebaseApp app = await Firebase.initializeApp(
     name: 'test',
     options: const FirebaseOptions(
       appId: '1:79601577497:ios:5f2bcc6ba8cecddd',

--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -21,11 +21,11 @@ void main() {
         apiKey: 'AIzaSyArgmRGfB5kiQT6CunAOmKRVKEsxKmy6YI-G72PVU',
         projectId: 'flutter-firestore',
       );
-      final FirebaseApp app = await FirebaseCore.instance.initializeApp(
+      final FirebaseApp app = await Firebase.initializeApp(
         name: 'test',
         options: firebaseOptions,
       );
-      final FirebaseApp app2 = await FirebaseCore.instance.initializeApp(
+      final FirebaseApp app2 = await Firebase.initializeApp(
         name: 'test2',
         options: firebaseOptions,
       );

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/cloud_firestore_platform_interface.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/cloud_firestore_platform_interface.dart
@@ -44,7 +44,7 @@ abstract class FirestorePlatform extends PlatformInterface {
 
   /// Create an instance using [app]
   FirestorePlatform({FirebaseApp app})
-      : app = app ?? FirebaseCore.instance.app(),
+      : app = app ?? Firebase.app(),
         super(token: _token);
 
   static final Object _token = Object();

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -22,7 +22,7 @@ import 'utils/maps.dart';
 class MethodChannelFirestore extends FirestorePlatform {
   /// Create an instance of [MethodChannelFirestore] with optional [FirebaseApp]
   MethodChannelFirestore({FirebaseApp app})
-      : super(app: app ?? FirebaseCore.instance.app()) {
+      : super(app: app ?? Firebase.app()) {
     if (_initialized) return;
     channel.setMethodCallHandler((MethodCall call) async {
       if (call.method == 'QuerySnapshot') {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_transaction.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_transaction.dart
@@ -22,8 +22,7 @@ class MethodChannelTransaction extends TransactionPlatform {
       : _transactionId = transactionId,
         super(appName == defaultFirebaseAppName
             ? FirestorePlatform.instance
-            : FirestorePlatform.instanceFor(
-                app: FirebaseCore.instance.app(appName)));
+            : FirestorePlatform.instanceFor(app: Firebase.app(appName)));
 
   @override
   Future<DocumentSnapshotPlatform> doGet(

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
@@ -97,7 +97,7 @@ class FirestoreMessageCodec extends StandardMessageCodec {
         final int appNameLength = readSize(buffer);
         final String appName =
             utf8.decoder.convert(buffer.getUint8List(appNameLength));
-        final FirebaseApp app = FirebaseCore.instance.app(appName);
+        final FirebaseApp app = Firebase.app(appName);
         final FirestorePlatform firestore =
             FirestorePlatform.instanceFor(app: app);
         final int pathLength = readSize(buffer);

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/document_reference_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   group("$DocumentReferencePlatform()", () {
     setUpAll(() async {
-      await FirebaseCore.instance.initializeApp();
+      await Firebase.initializeApp();
     });
     test("Parent", () {
       final document = TestDocumentReference._();

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_cloud_firestore_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_cloud_firestore_test.dart
@@ -20,7 +20,7 @@ void main() {
   initializeMethodChannel();
   FirebaseApp app;
   setUpAll(() async {
-    app = await FirebaseCore.instance.initializeApp(
+    app = await Firebase.initializeApp(
       name: 'testApp',
       options: const FirebaseOptions(
         appId: '1:1234567890:ios:42424242424242',
@@ -29,7 +29,7 @@ void main() {
         messagingSenderId: '1234567890',
       ),
     );
-    await FirebaseCore.instance.initializeApp(
+    await Firebase.initializeApp(
       name: 'testApp2',
       options: const FirebaseOptions(
         appId: '1:1234567890:ios:42424242424242',
@@ -72,7 +72,7 @@ void main() {
             // Otherwise the first request didn't have the time to finish.
             // ignore: unawaited_futures
             Future<void>.delayed(Duration.zero).then<void>((_) {
-              // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
+              // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.`
               // https://github.com/flutter/flutter/issues/33446
               // ignore: deprecated_member_use
               BinaryMessages.handlePlatformMessage(
@@ -190,12 +190,12 @@ void main() {
 
     test('multiple apps', () async {
       expect(FirestorePlatform.instance, equals(MethodChannelFirestore()));
-      final FirebaseApp app = FirebaseCore.instance.app(firestore.app.name);
+      final FirebaseApp app = Firebase.app(firestore.app.name);
       expect(firestore, equals(MethodChannelFirestore(app: app)));
     });
 
     test('settings', () async {
-      final FirebaseApp app = FirebaseCore.instance.app("testApp2");
+      final FirebaseApp app = Firebase.app("testApp2");
       final MethodChannelFirestore firestoreWithSettings =
           MethodChannelFirestore(app: app);
       await firestoreWithSettings.settings(

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_collection_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_collection_reference_test.dart
@@ -21,7 +21,7 @@ void main() {
   MethodChannelCollectionReference _testCollection;
 
   setUpAll(() async {
-    await FirebaseCore.instance.initializeApp(
+    await Firebase.initializeApp(
       name: 'testApp',
       options: const FirebaseOptions(
         appId: '1:1234567890:ios:42424242424242',

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_document_reference_test.dart
@@ -19,7 +19,7 @@ void main() {
     FieldValuePlatform mockFieldValue;
 
     setUpAll(() async {
-      await FirebaseCore.instance.initializeApp(
+      await Firebase.initializeApp(
         name: 'testApp',
         options: const FirebaseOptions(
           appId: '1:1234567890:ios:42424242424242',

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_field_value_factory_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_field_value_factory_test.dart
@@ -18,7 +18,7 @@ void main() {
   initializeMethodChannel();
   group("$MethodChannelFieldValueFactory()", () {
     setUpAll(() async {
-      await FirebaseCore.instance.initializeApp(
+      await Firebase.initializeApp(
         name: 'testApp',
         options: const FirebaseOptions(
           appId: '1:1234567890:ios:42424242424242',

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/query_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   group("$QueryPlatform()", () {
     setUpAll(() async {
-      await FirebaseCore.instance.initializeApp(
+      await Firebase.initializeApp(
         name: 'testApp',
         options: const FirebaseOptions(
           appId: '1:1234567890:ios:42424242424242',

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/test_common.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/test_common.dart
@@ -22,8 +22,8 @@ void initializeMethodChannel() {
   );
 
   TestWidgetsFlutterBinding.ensureInitialized();
-  MethodChannelFirebaseCore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'FirebaseCore#initializeCore') {
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
       return [
         {
           'name': '[DEFAULT]',
@@ -37,7 +37,7 @@ void initializeMethodChannel() {
         }
       ];
     }
-    if (call.method == 'FirebaseCore#initializeApp') {
+    if (call.method == 'Firebase#initializeApp') {
       return {
         'name': call.arguments['appName'],
         'options': call.arguments['options'],

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/transaction_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/transaction_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   group("MethodChannelTransaction()", () {
     setUpAll(() async {
-      await FirebaseCore.instance.initializeApp(
+      await Firebase.initializeApp(
         name: 'testApp',
         options: const FirebaseOptions(
           appId: '1:1234567890:ios:42424242424242',

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -30,7 +30,7 @@ class FirestoreWeb extends FirestorePlatform {
   /// If [app] is null then the created instance will use the default [FirebaseApp]
   FirestoreWeb({FirebaseApp app})
       : _webFirestore = firebase.firestore(firebase.app((app ?? '[DEFAULT]'))),
-        super(app: app ?? FirebaseCore.instance.app()) {
+        super(app: app ?? Firebase.app()) {
     FieldValueFactoryPlatform.instance = FieldValueFactoryWeb();
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/test/test_common.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/test/test_common.dart
@@ -50,7 +50,7 @@ web.Firestore mockFirestore() {
     })
   });
   js.context['firebase'] = firebaseMock;
-  FirebaseCorePlatform.instance = FirebaseCoreWeb();
+  FirebasePlatform.instance = FirebaseCoreWeb();
   FirestorePlatform.instance = FirestoreWeb();
   return mockFirestoreWeb;
 }

--- a/packages/cloud_functions/cloud_functions/example/lib/main.dart
+++ b/packages/cloud_functions/cloud_functions/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:cloud_functions/cloud_functions.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await FirebaseCore.instance.initializeApp();
+  await Firebase.initializeApp();
   runApp(MyApp());
 }
 

--- a/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
+++ b/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
@@ -11,7 +11,7 @@ void main() {
   E2EWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await FirebaseCore.instance.initializeApp();
+    await Firebase.initializeApp();
   });
 
   testWidgets('call', (WidgetTester tester) async {

--- a/packages/cloud_functions/cloud_functions/lib/src/cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/cloud_functions.dart
@@ -17,7 +17,7 @@ class CloudFunctionsException implements Exception {
 /// You can get an instance by calling [CloudFunctions.instance].
 class CloudFunctions {
   CloudFunctions({FirebaseApp app, String region})
-      : _app = app ?? FirebaseCore.instance.app(),
+      : _app = app ?? Firebase.app(),
         _region = region;
 
   static CloudFunctions _instance = CloudFunctions();

--- a/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart
@@ -17,10 +17,10 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
 
     setUp(() async {
-      await FirebaseCore.instance.initializeApp();
-      await FirebaseCore.instance.initializeApp(
+      await Firebase.initializeApp();
+      await Firebase.initializeApp(
         name: '1337',
-        options: FirebaseCore.instance.app().options,
+        options: Firebase.app().options,
       );
 
       MethodChannelCloudFunctions.channel
@@ -42,10 +42,10 @@ void main() {
       await CloudFunctions.instance
           .getHttpsCallable(functionName: 'baz')
           .call();
-      final HttpsCallable callable = CloudFunctions(
-              app: FirebaseCore.instance.app('1337'), region: 'space')
-          .getHttpsCallable(functionName: 'qux')
-            ..timeout = const Duration(days: 300);
+      final HttpsCallable callable =
+          CloudFunctions(app: Firebase.app('1337'), region: 'space')
+              .getHttpsCallable(functionName: 'qux')
+                ..timeout = const Duration(days: 300);
       await callable.call(<String, dynamic>{
         'quux': 'quuz',
       });

--- a/packages/cloud_functions/cloud_functions/test/test_common.dart
+++ b/packages/cloud_functions/cloud_functions/test/test_common.dart
@@ -7,8 +7,8 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
 
 void initializeMethodChannel() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  MethodChannelFirebaseCore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'FirebaseCore#initializeCore') {
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
       return [
         {
           'name': '[DEFAULT]',
@@ -22,7 +22,7 @@ void initializeMethodChannel() {
         }
       ];
     }
-    if (call.method == 'FirebaseCore#initializeApp') {
+    if (call.method == 'Firebase#initializeApp') {
       return {
         'name': call.arguments['appName'],
         'options': call.arguments['options'],

--- a/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart
@@ -15,7 +15,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
     FirebaseApp app;
     setUp(() async {
-      app = await FirebaseCore.instance.initializeApp();
+      app = await Firebase.initializeApp();
       MethodChannelCloudFunctions.channel
           .setMockMethodCallHandler((MethodCall methodCall) async {
         log.add(methodCall);

--- a/packages/cloud_functions/cloud_functions_platform_interface/test/test_common.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/test/test_common.dart
@@ -11,8 +11,8 @@ typedef MethodCallCallback = dynamic Function(MethodCall methodCall);
 
 void initializeMethodChannel() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  MethodChannelFirebaseCore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'FirebaseCore#initializeCore') {
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
       return [
         {
           'name': '[DEFAULT]',
@@ -26,7 +26,7 @@ void initializeMethodChannel() {
         }
       ];
     }
-    if (call.method == 'FirebaseCore#initializeApp') {
+    if (call.method == 'Firebase#initializeApp') {
       return {
         'name': call.arguments['appName'],
         'options': call.arguments['options'],

--- a/packages/cloud_functions/cloud_functions_web/test/cloud_functions_web_test.dart
+++ b/packages/cloud_functions/cloud_functions_web/test/cloud_functions_web_test.dart
@@ -60,7 +60,7 @@ void main() {
                 ))),
       ));
 
-      FirebaseCorePlatform.instance = FirebaseCoreWeb();
+      FirebasePlatform.instance = FirebaseCoreWeb();
       CloudFunctionsPlatform.instance = CloudFunctionsWeb();
 
       // install loggingCall on the HttpsCallable mock as the thing that gets

--- a/packages/firebase_admob/example/lib/main.dart
+++ b/packages/firebase_admob/example/lib/main.dart
@@ -16,7 +16,7 @@ const String testDevice = 'YOUR_DEVICE_ID';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await FirebaseCore.instance.initializeApp();
+  await Firebase.initializeApp();
   runApp(MyApp());
 }
 

--- a/packages/firebase_auth/firebase_auth/example/test_driver/firebase_auth_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/firebase_auth_e2e.dart
@@ -13,7 +13,7 @@ void main() {
   E2EWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await FirebaseCore.instance.initializeApp();
+    await Firebase.initializeApp();
   });
 
   group('$FirebaseAuth', () {

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -15,8 +15,7 @@ class FirebaseAuth {
   }
 
   /// Provides an instance of this class corresponding to the default app.
-  static final FirebaseAuth instance =
-      FirebaseAuth._(FirebaseCore.instance.app());
+  static final FirebaseAuth instance = FirebaseAuth._(Firebase.app());
 
   final FirebaseApp app;
 

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -91,7 +91,7 @@ void main() {
     FirebaseApp app;
 
     setUpAll(() async {
-      app = await FirebaseCore.instance.initializeApp(
+      app = await Firebase.initializeApp(
           name: appName,
           options: const FirebaseOptions(
             appId: '1:1234567890:ios:42424242424242',

--- a/packages/firebase_auth/firebase_auth/test/test_common.dart
+++ b/packages/firebase_auth/firebase_auth/test/test_common.dart
@@ -10,8 +10,8 @@ typedef MethodCallCallback = dynamic Function(MethodCall methodCall);
 
 void initializeMethodChannel() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  MethodChannelFirebaseCore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'FirebaseCore#initializeCore') {
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
       return [
         {
           'name': '[DEFAULT]',
@@ -25,7 +25,7 @@ void initializeMethodChannel() {
         }
       ];
     }
-    if (call.method == 'FirebaseCore#initializeApp') {
+    if (call.method == 'Firebase#initializeApp') {
       return {
         'name': call.arguments['appName'],
         'options': call.arguments['options'],

--- a/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
+++ b/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
@@ -26,7 +26,7 @@ void main() {
         ),
       ));
 
-      FirebaseCorePlatform.instance = FirebaseCoreWeb();
+      FirebasePlatform.instance = FirebaseCoreWeb();
       FirebaseAuthPlatform.instance = FirebaseAuthWeb();
     });
 

--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 1.0.0-1.0.pre
 
-* DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `FirebaseCore.instance.initializeApp` method.
-* DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `FirebaseCore.instance.apps` property.
+* DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
+* DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.
   * Previously, `allApps` was async & `apps` is now synchronous.
-* DEPRECATED: `FirebaseApp.appNamed` method is now deprecated in favor of the `FirebaseCore.instance.app` method.
+* DEPRECATED: `FirebaseApp.appNamed` method is now deprecated in favor of the `Firebase.app` method.
 * BREAKING: `FirebaseApp.options` getter is now synchronous.
 
 * `FirebaseOptions` has been reworked to better match web property names:

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -217,10 +217,10 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
     Task<?> methodCallTask;
 
     switch (call.method) {
-      case "FirebaseCore#initializeApp":
+      case "Firebase#initializeApp":
         methodCallTask = initializeApp(call.arguments());
         break;
-      case "FirebaseCore#initializeCore":
+      case "Firebase#initializeCore":
         methodCallTask = initializeCore();
         break;
       case "FirebaseApp#setAutomaticDataCollectionEnabled":

--- a/packages/firebase_core/firebase_core/darwin/Classes/FLTFirebaseCorePlugin.m
+++ b/packages/firebase_core/firebase_core/darwin/Classes/FLTFirebaseCorePlugin.m
@@ -8,9 +8,9 @@
 // Flutter method channel name.
 NSString *const kFLTFirebaseCoreChannelName = @"plugins.flutter.io/firebase_core";
 
-// FirebaseCore method names.
-NSString *const kMethodCoreInitializeApp = @"FirebaseCore#initializeApp";
-NSString *const kMethodCoreInitializeCore = @"FirebaseCore#initializeCore";
+// Firebase method names.
+NSString *const kMethodCoreInitializeApp = @"Firebase#initializeApp";
+NSString *const kMethodCoreInitializeCore = @"Firebase#initializeCore";
 
 // FirebaseApp method names.
 NSString *const kMethodAppDelete = @"FirebaseApp#delete";

--- a/packages/firebase_core/firebase_core/example/lib/main.dart
+++ b/packages/firebase_core/firebase_core/example/lib/main.dart
@@ -19,32 +19,32 @@ class MyApp extends StatelessWidget {
   );
 
   Future<void> initializeDefault() async {
-    FirebaseApp app = await FirebaseCore.instance.initializeApp();
+    FirebaseApp app = await Firebase.initializeApp();
     assert(app != null);
     print('Initialized default app $app');
   }
 
   Future<void> initializeSecondary() async {
-    FirebaseApp app = await FirebaseCore.instance
-        .initializeApp(name: name, options: firebaseOptions);
+    FirebaseApp app =
+        await Firebase.initializeApp(name: name, options: firebaseOptions);
 
     assert(app != null);
     print('Initialized $app');
   }
 
   void apps() {
-    final List<FirebaseApp> apps = FirebaseCore.instance.apps;
+    final List<FirebaseApp> apps = Firebase.apps;
     print('Currently initialized apps: $apps');
   }
 
   void options() {
-    final FirebaseApp app = FirebaseCore.instance.app(name);
+    final FirebaseApp app = Firebase.app(name);
     final FirebaseOptions options = app?.options;
     print('Current options for app $name: $options');
   }
 
   Future<void> delete() async {
-    final FirebaseApp app = FirebaseCore.instance.app(name);
+    final FirebaseApp app = Firebase.app(name);
     await app?.delete();
     print('App $name deleted');
   }

--- a/packages/firebase_core/firebase_core/example/test_driver/firebase_core_e2e.dart
+++ b/packages/firebase_core/firebase_core/example/test_driver/firebase_core_e2e.dart
@@ -11,7 +11,6 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   E2EWidgetsFlutterBinding.ensureInitialized();
 
-  FirebaseCore core;
   String testAppName = 'TestApp';
   FirebaseOptions testAppOptions;
   if (Platform.isIOS) {
@@ -32,26 +31,25 @@ void main() {
   }
 
   setUpAll(() async {
-    core = FirebaseCore.instance;
-    await core.initializeApp(name: testAppName, options: testAppOptions);
+    await Firebase.initializeApp(name: testAppName, options: testAppOptions);
   });
 
-  testWidgets('FirebaseCore.apps', (WidgetTester tester) async {
-    List<FirebaseApp> apps = core.apps;
+  testWidgets('Firebase.apps', (WidgetTester tester) async {
+    List<FirebaseApp> apps = Firebase.apps;
     expect(apps.length, 2);
     expect(apps[1].name, testAppName);
     expect(apps[1].options, testAppOptions);
   });
 
-  testWidgets('FirebaseCore.app()', (WidgetTester tester) async {
-    FirebaseApp app = core.app(testAppName);
+  testWidgets('Firebase.app()', (WidgetTester tester) async {
+    FirebaseApp app = Firebase.app(testAppName);
     expect(app.name, testAppName);
     expect(app.options, testAppOptions);
   });
 
-  testWidgets('FirebaseCore.app() Exception', (WidgetTester tester) async {
+  testWidgets('Firebase.app() Exception', (WidgetTester tester) async {
     try {
-      await core.app('NoApp');
+      await Firebase.app('NoApp');
     } on FirebaseException catch (e) {
       expect(e, noAppExists('NoApp'));
       return;
@@ -59,16 +57,16 @@ void main() {
   });
 
   testWidgets('FirebaseApp.delete()', (WidgetTester tester) async {
-    await core.initializeApp(name: 'SecondaryApp', options: testAppOptions);
-    expect(core.apps.length, 3);
-    FirebaseApp app = core.app('SecondaryApp');
+    await Firebase.initializeApp(name: 'SecondaryApp', options: testAppOptions);
+    expect(Firebase.apps.length, 3);
+    FirebaseApp app = Firebase.app('SecondaryApp');
     await app.delete();
-    expect(core.apps.length, 2);
+    expect(Firebase.apps.length, 2);
   });
 
   testWidgets('FirebaseApp.setAutomaticDataCollectionEnabled()',
       (WidgetTester tester) async {
-    FirebaseApp app = core.app(testAppName);
+    FirebaseApp app = Firebase.app(testAppName);
     bool enabled = app.isAutomaticDataCollectionEnabled;
     await app.setAutomaticDataCollectionEnabled(!enabled);
     expect(app.isAutomaticDataCollectionEnabled, !enabled);
@@ -76,7 +74,7 @@ void main() {
 
   testWidgets('FirebaseApp.setAutomaticResourceManagementEnabled()',
       (WidgetTester tester) async {
-    FirebaseApp app = core.app(testAppName);
+    FirebaseApp app = Firebase.app(testAppName);
     await app.setAutomaticResourceManagementEnabled(true);
   });
 }

--- a/packages/firebase_core/firebase_core/lib/firebase_core.dart
+++ b/packages/firebase_core/firebase_core/lib/firebase_core.dart
@@ -7,7 +7,7 @@ library firebase_core;
 import 'dart:async';
 
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    hide MethodChannelFirebaseApp, MethodChannelFirebaseCore;
+    hide MethodChannelFirebaseApp, MethodChannelFirebase;
 import 'package:meta/meta.dart';
 import 'package:quiver/core.dart';
 
@@ -15,5 +15,4 @@ export 'package:firebase_core_platform_interface/firebase_core_platform_interfac
     show FirebaseOptions, defaultFirebaseAppName, FirebaseException;
 
 part 'src/firebase_app.dart';
-
-part 'src/firebase_core.dart';
+part 'src/firebase.dart';

--- a/packages/firebase_core/firebase_core/lib/src/firebase.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase.dart
@@ -6,7 +6,21 @@ part of firebase_core;
 
 /// The entry point for accessing Firebase.
 class Firebase {
-  static FirebasePlatform _delegate = FirebasePlatform.instance;
+  // Cached & lazily loaded instance of [FirebasePlatform].
+  // Avoids a [MethodChannelFirebase] being initialized until the user
+  // starts using Firebase.
+  // The property is visible for testing to allow tests to set a mock
+  // instance directly as a static property since the class is not initialized.
+  @visibleForTesting
+  // ignore: public_member_api_docs
+  static FirebasePlatform delegatePackingProperty;
+
+  static FirebasePlatform get _delegate {
+    if (delegatePackingProperty == null) {
+      delegatePackingProperty = FirebasePlatform.instance;
+    }
+    return delegatePackingProperty;
+  }
 
   // Ensures end-users cannot initialize the class.
   Firebase._();

--- a/packages/firebase_core/firebase_core/lib/src/firebase.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase.dart
@@ -5,19 +5,14 @@
 part of firebase_core;
 
 /// The entry point for accessing Firebase.
-///
-/// You can get an instance by calling [FirebaseCore.instance].
-class FirebaseCore {
-  FirebaseCorePlatform _delegate = FirebaseCorePlatform.instance;
+class Firebase {
+  static FirebasePlatform _delegate = FirebasePlatform.instance;
 
   // Ensures end-users cannot initialize the class.
-  FirebaseCore._();
-
-  /// Returns the entry point for accessing the class.
-  static FirebaseCore get instance => FirebaseCore._();
+  Firebase._();
 
   /// Returns a list of all [FirebaseApp] instances that have been created.
-  List<FirebaseApp> get apps {
+  static List<FirebaseApp> get apps {
     return _delegate.apps
         .map((app) => FirebaseApp._(app))
         .toList(growable: false);
@@ -28,7 +23,7 @@ class FirebaseCore {
   ///
   /// The default app instance cannot be initialized here and should be created
   /// using the platform Firebase integration.
-  Future<FirebaseApp> initializeApp(
+  static Future<FirebaseApp> initializeApp(
       {String name, FirebaseOptions options}) async {
     FirebaseAppPlatform app =
         await _delegate.initializeApp(name: name, options: options);
@@ -39,7 +34,7 @@ class FirebaseCore {
   ///
   /// If no name is provided, the default app instance is returned.
   /// Throws if the app does not exist.
-  FirebaseApp app([String name = defaultFirebaseAppName]) {
+  static FirebaseApp app([String name = defaultFirebaseAppName]) {
     FirebaseAppPlatform app = _delegate.app(name);
     return app == null ? null : FirebaseApp._(app);
   }
@@ -47,7 +42,7 @@ class FirebaseCore {
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
-    if (other is! FirebaseCore) return false;
+    if (other is! Firebase) return false;
     return other.hashCode == hashCode;
   }
 
@@ -55,5 +50,5 @@ class FirebaseCore {
   int get hashCode => this.toString().hashCode;
 
   @override
-  String toString() => '$FirebaseCore';
+  String toString() => '$Firebase';
 }

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -6,7 +6,7 @@ part of firebase_core;
 
 /// Represents a single Firebase app instance.
 ///
-/// You can get an instance by calling [FirebaseCore.instance.app()].
+/// You can get an instance by calling [Firebase.app()].
 class FirebaseApp {
   FirebaseAppPlatform _delegate;
 
@@ -27,31 +27,31 @@ class FirebaseApp {
     await _delegate.delete();
   }
 
-  @Deprecated("Deprecated in favor of FirebaseCore.instance.app()")
+  @Deprecated("Deprecated in favor of Firebase.app()")
   // ignore: public_member_api_docs
   static FirebaseApp appNamed(String name) {
-    return FirebaseCore.instance.app(name);
+    return Firebase.app(name);
   }
 
-  @Deprecated("Deprecated in favor of FirebaseCore.instance.apps")
+  @Deprecated("Deprecated in favor of Firebase.apps")
   // ignore: public_member_api_docs
   static Future<List<FirebaseApp>> allApps() async {
-    return FirebaseCore.instance.apps;
+    return Firebase.apps;
   }
 
-  @Deprecated("Deprecated in favor of FirebaseCore.instance.initializeApp()")
+  @Deprecated("Deprecated in favor of Firebase.initializeApp()")
   // ignore: public_member_api_docs
   static Future<FirebaseApp> configure({
     @required String name,
     @required FirebaseOptions options,
   }) {
-    return FirebaseCore.instance.initializeApp(name: name, options: options);
+    return Firebase.initializeApp(name: name, options: options);
   }
 
-  @Deprecated("Deprecated in favor of FirebaseCore.instance.app()")
+  @Deprecated("Deprecated in favor of Firebase.app()")
   // ignore: public_member_api_docs
   static FirebaseApp get instance {
-    return FirebaseCore.instance.app();
+    return Firebase.app();
   }
 
   @Deprecated("Deprecated in favor of defaultFirebaseAppName")

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     setUp(() async {
       mock = MockFirebaseCore();
-      FirebasePlatform.instance = mock;
+      Firebase.delegatePackingProperty = mock;
 
       final FirebaseAppPlatform platformApp =
           FirebaseAppPlatform(testAppName, testOptions);

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     setUp(() async {
       mock = MockFirebaseCore();
-      FirebaseCorePlatform.instance = mock;
+      FirebasePlatform.instance = mock;
 
       final FirebaseAppPlatform platformApp =
           FirebaseAppPlatform(testAppName, testOptions);
@@ -38,13 +38,13 @@ void main() {
     });
 
     test('.apps', () {
-      List<FirebaseApp> apps = FirebaseCore.instance.apps;
+      List<FirebaseApp> apps = Firebase.apps;
       verify(mock.apps);
-      expect(apps[0], FirebaseCore.instance.app(testAppName));
+      expect(apps[0], Firebase.app(testAppName));
     });
 
     test('.app()', () {
-      FirebaseApp app = FirebaseCore.instance.app(testAppName);
+      FirebaseApp app = Firebase.app(testAppName);
       verify(mock.app(testAppName));
 
       expect(app.name, testAppName);
@@ -52,9 +52,9 @@ void main() {
     });
 
     test('.initializeApp()', () async {
-      FirebaseApp initializedApp = await FirebaseCore.instance
-          .initializeApp(name: testAppName, options: testOptions);
-      FirebaseApp app = FirebaseCore.instance.app(testAppName);
+      FirebaseApp initializedApp =
+          await Firebase.initializeApp(name: testAppName, options: testOptions);
+      FirebaseApp app = Firebase.app(testAppName);
 
       expect(initializedApp, app);
       verifyInOrder([
@@ -67,4 +67,4 @@ void main() {
 
 class MockFirebaseCore extends Mock
     with MockPlatformInterfaceMixin
-    implements FirebaseCorePlatform {}
+    implements FirebasePlatform {}

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.0.0-1.0.pre
 
-* DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `FirebaseCore.instance.initializeApp` method.
-* DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `FirebaseCore.instance.apps` property.
+* DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
+* DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.
   * Previously, `allApps` was asynchronous where it is now synchronous.
-* DEPRECATED: `FirebaseApp.appNamed` method is now deprecated in favor of the `FirebaseCore.instance.app` method.
+* DEPRECATED: `FirebaseApp.appNamed` method is now deprecated in favor of the `Firebase.app` method.
 * BREAKING: `FirebaseApp.options` getter is now synchronous.
 
 * `FirebaseOptions` has been reworked to better match web property names:

--- a/packages/firebase_core/firebase_core_platform_interface/README.md
+++ b/packages/firebase_core/firebase_core_platform_interface/README.md
@@ -9,10 +9,10 @@ same interface.
 # Usage
 
 To implement a new platform-specific implementation of `firebase_core`, extend
-[`FirebaseCorePlatform`][2] with an implementation that performs the
+[`FirebasePlatform`][2] with an implementation that performs the
 platform-specific behavior, and when you register your plugin, set the default
-`FirebaseCorePlatform` by calling
-`FirebaseCorePlatform.instance = MyFirebaseCore()`.
+`FirebasePlatform` by calling
+`FirebasePlatform.instance = MyFirebaseCore()`.
 
 # Note on breaking changes
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/firebase_core_platform_interface.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/firebase_core_platform_interface.dart
@@ -22,11 +22,11 @@ part 'src/firebase_options.dart';
 
 part 'src/method_channel/method_channel_firebase_app.dart';
 
-part 'src/method_channel/method_channel_firebase_core.dart';
+part 'src/method_channel/method_channel_firebase.dart';
 
 part 'src/platform_interface/platform_interface_firebase_app.dart';
 
-part 'src/platform_interface/platform_interface_firebase_core.dart';
+part 'src/platform_interface/platform_interface_firebase.dart';
 
 part 'src/platform_interface/platform_interface_firebase_plugin.dart';
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_core_exceptions.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_core_exceptions.dart
@@ -11,7 +11,7 @@ FirebaseException noAppExists(String appName) {
       plugin: 'core',
       code: 'no-app',
       message:
-          "No Firebase App '${appName}' has been created - call FirebaseCore.instance.initializeApp()");
+          "No Firebase App '${appName}' has been created - call Firebase.initializeApp()");
 }
 
 /// Throws a consistent cross-platform error message when an app is being created

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_exception.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_exception.dart
@@ -9,7 +9,7 @@ part of firebase_core_platform_interface;
 ///
 /// ```dart
 /// try {
-///   await FirebaseCore.instance.initializeApp();
+///   await Firebase.initializeApp();
 /// } catch (e) {
 ///   print(e.toString());
 /// }
@@ -20,7 +20,7 @@ class FirebaseException implements Exception {
   ///
   /// ```dart
   /// try {
-  ///   await FirebaseCore.instance.initializeApp();
+  ///   await Firebase.initializeApp();
   /// } catch (e) {
   ///   print(e.toString());
   /// }

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
@@ -8,7 +8,7 @@ part of firebase_core_platform_interface;
 /// The options used to configure a Firebase app.
 ///
 /// ```dart
-/// await FirebaseCore.instance.initializeApp(
+/// await Firebase.initializeApp(
 ///   name: 'SecondaryApp',
 ///   options: const FirebaseOptions(
 ///     apiKey: '...',
@@ -22,7 +22,7 @@ class FirebaseOptions {
   /// The options used to configure a Firebase app.
   ///
   /// ```dart
-  /// await FirebaseCore.instance.initializeApp(
+  /// await Firebase.initializeApp(
   ///   name: 'SecondaryApp',
   ///   options: const FirebaseOptions(
   ///     apiKey: '...',

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
@@ -4,10 +4,8 @@
 
 part of firebase_core_platform_interface;
 
-/// The [FirebaseCorePlatform] implementation that delegates to a [MethodChannel].
-///
-/// You can get an instance by calling [FirebaseCore.instance].
-class MethodChannelFirebaseCore extends FirebaseCorePlatform {
+/// The [FirebasePlatform] implementation that delegates to a [MethodChannel].
+class MethodChannelFirebase extends FirebasePlatform {
   /// Tracks local [MethodChannelFirebaseApp] instances.
   @visibleForTesting
   static Map<String, MethodChannelFirebaseApp> appInstances = {};
@@ -22,7 +20,7 @@ class MethodChannelFirebaseCore extends FirebaseCorePlatform {
     'plugins.flutter.io/firebase_core',
   );
 
-  /// Calls the native FirebaseCore#initializeCore method.
+  /// Calls the native Firebase#initializeCore method.
   ///
   /// Before any plugins can be consumed, any platforms using the [MethodChannel]
   /// can use initializeCore method to return any initialization data, such as
@@ -30,14 +28,14 @@ class MethodChannelFirebaseCore extends FirebaseCorePlatform {
   /// for a plugin to function correctly before usage.
   Future<void> _initializeCore() async {
     List<Map> apps = await channel.invokeListMethod<Map>(
-      'FirebaseCore#initializeCore',
+      'Firebase#initializeCore',
     );
 
     apps.forEach(_initializeFirebaseAppFromMap);
     isCoreInitialized = true;
   }
 
-  /// Creates and attaches a new [MethodChannelFirebaseApp] to the [MethodChannelFirebaseCore]
+  /// Creates and attaches a new [MethodChannelFirebaseApp] to the [MethodChannelFirebase]
   /// and adds any constants to the [FirebasePluginPlatform] class.
   void _initializeFirebaseAppFromMap(Map<dynamic, dynamic> map) {
     MethodChannelFirebaseApp methodChannelFirebaseApp =
@@ -47,7 +45,7 @@ class MethodChannelFirebaseCore extends FirebaseCorePlatform {
       isAutomaticDataCollectionEnabled: map['isAutomaticDataCollectionEnabled'],
     );
 
-    MethodChannelFirebaseCore.appInstances[methodChannelFirebaseApp.name] =
+    MethodChannelFirebase.appInstances[methodChannelFirebaseApp.name] =
         methodChannelFirebaseApp;
 
     FirebasePluginPlatform
@@ -100,7 +98,7 @@ class MethodChannelFirebaseCore extends FirebaseCorePlatform {
     }
 
     _initializeFirebaseAppFromMap(await channel.invokeMapMethod(
-      'FirebaseCore#initializeApp',
+      'Firebase#initializeApp',
       <String, dynamic>{'appName': name, 'options': options.asMap},
     ));
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart
@@ -10,7 +10,7 @@ part of firebase_core_platform_interface;
 /// instance, for example:
 ///
 /// ```dart
-/// FirebaseCore.instance.app('SecondaryApp`);
+/// Firebase.app('SecondaryApp`);
 /// ```
 class MethodChannelFirebaseApp extends FirebaseAppPlatform {
   // ignore: public_member_api_docs
@@ -47,12 +47,12 @@ class MethodChannelFirebaseApp extends FirebaseAppPlatform {
       return;
     }
 
-    await MethodChannelFirebaseCore.channel.invokeMethod<void>(
+    await MethodChannelFirebase.channel.invokeMethod<void>(
       'FirebaseApp#delete',
       <String, dynamic>{'appName': name, 'options': options.asMap},
     );
 
-    MethodChannelFirebaseCore.appInstances.remove(name);
+    MethodChannelFirebase.appInstances.remove(name);
     FirebasePluginPlatform._constantsForPluginApps.remove(name);
     _isDeleted = true;
   }
@@ -61,7 +61,7 @@ class MethodChannelFirebaseApp extends FirebaseAppPlatform {
   @override
   Future<void> setAutomaticDataCollectionEnabled(bool enabled) async {
     assert(enabled != null);
-    await MethodChannelFirebaseCore.channel.invokeMethod<void>(
+    await MethodChannelFirebase.channel.invokeMethod<void>(
       'FirebaseApp#setAutomaticDataCollectionEnabled',
       <String, dynamic>{'appName': name, 'enabled': enabled},
     );
@@ -73,7 +73,7 @@ class MethodChannelFirebaseApp extends FirebaseAppPlatform {
   @override
   Future<void> setAutomaticResourceManagementEnabled(bool enabled) async {
     assert(enabled != null);
-    await MethodChannelFirebaseCore.channel.invokeMethod<void>(
+    await MethodChannelFirebase.channel.invokeMethod<void>(
       'FirebaseApp#setAutomaticResourceManagementEnabled',
       <String, dynamic>{'appName': name, 'enabled': enabled},
     );

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase.dart
@@ -11,24 +11,24 @@ part of firebase_core_platform_interface;
 /// changes. Extending this class (using `extends`) ensures that the subclass
 /// will get the default implementation, while platform implementations that
 /// `implements` this interface will be broken by newly added
-/// [FirebaseCorePlatform] methods.
-abstract class FirebaseCorePlatform extends PlatformInterface {
+/// [FirebasePlatform] methods.
+abstract class FirebasePlatform extends PlatformInterface {
   // ignore: public_member_api_docs
-  FirebaseCorePlatform() : super(token: _token);
+  FirebasePlatform() : super(token: _token);
 
   static final Object _token = Object();
 
-  /// The default instance of [FirebaseCorePlatform] to use.
+  /// The default instance of [FirebasePlatform] to use.
   ///
   /// Platform-specific plugins should override this with their own class
-  /// that extends [FirebaseCorePlatform] when they register themselves.
+  /// that extends [FirebasePlatform] when they register themselves.
   ///
-  /// Defaults to [MethodChannelFirebaseCore].
-  static FirebaseCorePlatform get instance => _instance;
+  /// Defaults to [MethodChannelFirebase].
+  static FirebasePlatform get instance => _instance;
 
-  static FirebaseCorePlatform _instance = MethodChannelFirebaseCore();
+  static FirebasePlatform _instance = MethodChannelFirebase();
 
-  static set instance(FirebaseCorePlatform instance) {
+  static set instance(FirebasePlatform instance) {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_app.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_app.dart
@@ -6,7 +6,7 @@ part of firebase_core_platform_interface;
 
 /// A class storing the name and options of a Firebase app.
 ///
-/// This is created as a result of calling [FirebaseCorePlatform.initializeApp].
+/// This is created as a result of calling [FirebasePlatform.initializeApp].
 class FirebaseAppPlatform extends PlatformInterface {
   // ignore: public_member_api_docs
   FirebaseAppPlatform(this.name, this.options) : super(token: _token);

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_plugin.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_plugin.dart
@@ -15,7 +15,7 @@ abstract class FirebasePluginPlatform extends PlatformInterface {
 
   /// The global data store for all constants, for each plugin and [FirebaseAppPlatform] instance.
   ///
-  /// When Firebase is initialized by the user with [FirebaseCorePlatform.initializeApp],
+  /// When Firebase is initialized by the user with [FirebasePlatform.initializeApp],
   /// any constant values which are required before the plugins can be consumed are registered
   /// here. For example, calling [FirebaseAppPlatform.isAutomaticDataCollectionEnabled]
   /// requires that the value is synchronously available for use after initialization.

--- a/packages/firebase_core/firebase_core_platform_interface/test/method_channel_tests/method_channel_firebase_app_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/method_channel_tests/method_channel_firebase_app_test.dart
@@ -23,7 +23,7 @@ void main() {
         MethodChannelFirebaseApp('foo', testOptions);
 
     setUp(() async {
-      MethodChannelFirebaseCore.channel
+      MethodChannelFirebase.channel
           .setMockMethodCallHandler((MethodCall methodCall) async {
         methodCallLog.add(methodCall);
         print(methodCall);

--- a/packages/firebase_core/firebase_core_platform_interface/test/method_channel_tests/method_channel_firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/method_channel_tests/method_channel_firebase_core_test.dart
@@ -9,9 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('$MethodChannelFirebaseCore', () {
-    final MethodChannelFirebaseCore channelPlatform =
-        MethodChannelFirebaseCore();
+  group('$MethodChannelFirebase', () {
+    final MethodChannelFirebase channelPlatform = MethodChannelFirebase();
     final List<MethodCall> methodCallLog = <MethodCall>[];
 
     const FirebaseOptions testOptions = FirebaseOptions(
@@ -22,15 +21,15 @@ void main() {
     );
 
     setUp(() async {
-      MethodChannelFirebaseCore.isCoreInitialized = false;
-      MethodChannelFirebaseCore.appInstances = {};
+      MethodChannelFirebase.isCoreInitialized = false;
+      MethodChannelFirebase.appInstances = {};
 
-      MethodChannelFirebaseCore.channel
+      MethodChannelFirebase.channel
           .setMockMethodCallHandler((MethodCall methodCall) async {
         methodCallLog.add(methodCall);
 
         switch (methodCall.method) {
-          case 'FirebaseCore#initializeCore':
+          case 'Firebase#initializeCore':
             return [
               {
                 'name': defaultFirebaseAppName,
@@ -42,7 +41,7 @@ void main() {
                 },
               }
             ];
-          case 'FirebaseCore#initializeApp':
+          case 'Firebase#initializeApp':
             return <dynamic, dynamic>{
               'name': methodCall.arguments['appName'] ?? defaultFirebaseAppName,
               'options': <dynamic, dynamic>{
@@ -79,7 +78,7 @@ void main() {
           methodCallLog,
           <Matcher>[
             isMethodCall(
-              'FirebaseCore#initializeCore',
+              'Firebase#initializeCore',
               arguments: null,
             ),
           ],
@@ -94,12 +93,12 @@ void main() {
       group('no default app', () {
         // Mock no default app being available
         setUp(() {
-          MethodChannelFirebaseCore.channel
+          MethodChannelFirebase.channel
               .setMockMethodCallHandler((MethodCall methodCall) async {
             methodCallLog.add(methodCall);
 
             switch (methodCall.method) {
-              case 'FirebaseCore#initializeCore':
+              case 'Firebase#initializeCore':
                 return [];
               default:
                 return null;
@@ -143,18 +142,18 @@ void main() {
             methodCallLog,
             <Matcher>[
               isMethodCall(
-                'FirebaseCore#initializeCore',
+                'Firebase#initializeCore',
                 arguments: null,
               ),
               isMethodCall(
-                'FirebaseCore#initializeApp',
+                'Firebase#initializeApp',
                 arguments: <String, dynamic>{
                   'appName': 'foo',
                   'options': testOptions.asMap,
                 },
               ),
               isMethodCall(
-                'FirebaseCore#initializeApp',
+                'Firebase#initializeApp',
                 arguments: <String, dynamic>{
                   'appName': 'bar',
                   'options': testOptions.asMap,

--- a/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
@@ -10,30 +10,30 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('$FirebaseCorePlatform', () {
+  group('$FirebasePlatform', () {
     // should allow read of default app from native
-    test('$MethodChannelFirebaseCore is the default instance', () {
-      expect(FirebaseCorePlatform.instance, isA<MethodChannelFirebaseCore>());
+    test('$MethodChannelFirebase is the default instance', () {
+      expect(FirebasePlatform.instance, isA<MethodChannelFirebase>());
     });
 
     test('Can be extended', () {
-      FirebaseCorePlatform.instance = ExtendsFirebaseCorePlatform();
+      FirebasePlatform.instance = ExtendsFirebasePlatform();
     });
 
     test('Cannot be implemented with `implements`', () {
       expect(() {
-        FirebaseCorePlatform.instance = ImplementsFirebaseCorePlatform();
+        FirebasePlatform.instance = ImplementsFirebasePlatform();
       }, throwsNoSuchMethodError);
     });
 
     test('Can be mocked with `implements`', () {
       final FirebaseCoreMockPlatform mock = FirebaseCoreMockPlatform();
-      FirebaseCorePlatform.instance = mock;
+      FirebasePlatform.instance = mock;
     });
   });
 }
 
-class ImplementsFirebaseCorePlatform implements FirebaseCorePlatform {
+class ImplementsFirebasePlatform implements FirebasePlatform {
   @override
   Future<FirebaseAppPlatform> initializeApp(
           {String name, FirebaseOptions options}) =>
@@ -48,8 +48,8 @@ class ImplementsFirebaseCorePlatform implements FirebaseCorePlatform {
   List<FirebaseAppPlatform> get apps => null;
 }
 
-class ExtendsFirebaseCorePlatform extends FirebaseCorePlatform {}
+class ExtendsFirebasePlatform extends FirebasePlatform {}
 
 class FirebaseCoreMockPlatform extends Mock
     with MockPlatformInterfaceMixin
-    implements FirebaseCorePlatform {}
+    implements FirebasePlatform {}

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 1.0.0-1.0.pre
 
-* DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `FirebaseCore.instance.initializeApp` method.
-* DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `FirebaseCore.instance.apps` property.
+* DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
+* DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.
   * Previously, `allApps` was asynchronous where it is now synchronous.
-* DEPRECATED: `FirebaseApp.appNamed` method is now deprecated in favor of the `FirebaseCore.instance.app` method.
+* DEPRECATED: `FirebaseApp.appNamed` method is now deprecated in favor of the `Firebase.app` method.
 * BREAKING: `FirebaseApp.options` getter is now synchronous.
 
 * `FirebaseOptions` has been reworked to better match web property names:

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_app_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_app_web.dart
@@ -10,7 +10,7 @@ part of firebase_core_web;
 /// instance, for example:
 ///
 /// ```dart
-/// FirebaseCore.instance.app('SecondaryApp`);
+/// Firebase.app('SecondaryApp`);
 /// ```
 class FirebaseAppWeb extends FirebaseAppPlatform {
   FirebaseAppWeb._(String name, FirebaseOptions options) : super(name, options);

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -7,10 +7,10 @@ part of firebase_core_web;
 /// The entry point for accessing Firebase.
 ///
 /// You can get an instance by calling [FirebaseCore.instance].
-class FirebaseCoreWeb extends FirebaseCorePlatform {
+class FirebaseCoreWeb extends FirebasePlatform {
   /// Registers that [FirebaseCoreWeb] is the platform implementation.
   static void registerWith(Registrar registrar) {
-    FirebaseCorePlatform.instance = FirebaseCoreWeb();
+    FirebasePlatform.instance = FirebaseCoreWeb();
   }
 
   /// Returns all created [FirebaseAppPlatform] instances.

--- a/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
+++ b/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
@@ -15,12 +15,12 @@ import 'package:js/js_util.dart' as js_util;
 void main() {
   group('no default app', () {
     setUp(() async {
-      FirebaseCorePlatform.instance = FirebaseCoreWeb();
+      FirebasePlatform.instance = FirebaseCoreWeb();
     });
 
     test('should throw exception if no default app is available', () async {
       try {
-        await FirebaseCore.instance.initializeApp();
+        await Firebase.initializeApp();
       } on FirebaseException catch (e) {
         expect(e, coreNotInitialized());
         return;
@@ -32,13 +32,13 @@ void main() {
 
   group('.initializeApp()', () {
     setUp(() async {
-      FirebaseCorePlatform.instance = FirebaseCoreWeb();
+      FirebasePlatform.instance = FirebaseCoreWeb();
     });
 
     test('should throw exception if trying to initialize default app',
         () async {
       try {
-        await FirebaseCore.instance.initializeApp(name: defaultFirebaseAppName);
+        await Firebase.initializeApp(name: defaultFirebaseAppName);
       } on FirebaseException catch (e) {
         expect(e, noDefaultAppInitialization());
         return;
@@ -51,7 +51,7 @@ void main() {
       test('should throw exception if no options are provided with a named app',
           () async {
         try {
-          await FirebaseCore.instance.initializeApp(name: 'foo');
+          await Firebase.initializeApp(name: 'foo');
         } catch (e) {
           assert(
               e.toString().contains(
@@ -70,14 +70,14 @@ void main() {
         js_util.setProperty(error, 'code', 'app/no-app');
         throw error;
       }));
-      FirebaseCorePlatform.instance = FirebaseCoreWeb();
+      FirebasePlatform.instance = FirebaseCoreWeb();
     });
 
     test('should throw exception if no named app was found', () async {
       String name = 'foo';
 
       try {
-        FirebaseCore.instance.app(name);
+        Firebase.app(name);
       } on FirebaseException catch (e) {
         expect(e, noAppExists(name));
         return;

--- a/packages/firebase_core/firebase_core_web/test/firebase_core_web_test.dart
+++ b/packages/firebase_core/firebase_core_web/test/firebase_core_web_test.dart
@@ -26,12 +26,12 @@ void main() {
                     projectId: 'test'),
               )));
 
-      FirebaseCorePlatform.instance = FirebaseCoreWeb();
+      FirebasePlatform.instance = FirebaseCoreWeb();
     });
 
     test('.apps', () {
       js.context['firebase']['apps'] = js.JsArray<dynamic>();
-      final List<FirebaseApp> apps = FirebaseCore.instance.apps;
+      final List<FirebaseApp> apps = Firebase.apps;
       expect(apps, hasLength(0));
     });
 
@@ -47,7 +47,7 @@ void main() {
           },
         });
       });
-      final FirebaseApp app = FirebaseCore.instance.app('foo');
+      final FirebaseApp app = Firebase.app('foo');
       expect(app.name, equals('foo'));
 
       final FirebaseOptions options = await app.options;
@@ -83,7 +83,7 @@ void main() {
           'options': options,
         });
       });
-      final FirebaseApp app = await FirebaseCore.instance.initializeApp(
+      final FirebaseApp app = await Firebase.initializeApp(
         name: 'foo',
         options: const FirebaseOptions(
           apiKey: 'abc',

--- a/packages/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/example/lib/main.dart
@@ -12,7 +12,7 @@ import 'package:firebase_database/ui/firebase_animated_list.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final FirebaseApp app = await FirebaseCore.instance.initializeApp(
+  final FirebaseApp app = await Firebase.initializeApp(
     name: 'db2',
     options: Platform.isIOS
         ? FirebaseOptions(

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -16,7 +16,7 @@ void main() {
   FirebaseApp app;
 
   setUpAll(() async {
-    app = await FirebaseCore.instance.initializeApp(
+    app = await Firebase.initializeApp(
       name: 'testApp',
       options: const FirebaseOptions(
         appId: '1:1234567890:ios:42424242424242',

--- a/packages/firebase_database/test/test_common.dart
+++ b/packages/firebase_database/test/test_common.dart
@@ -7,8 +7,8 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
 
 void initializeMethodChannel() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  MethodChannelFirebaseCore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'FirebaseCore#initializeCore') {
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
       return [
         {
           'name': '[DEFAULT]',
@@ -22,7 +22,7 @@ void initializeMethodChannel() {
         }
       ];
     }
-    if (call.method == 'FirebaseCore#initializeApp') {
+    if (call.method == 'Firebase#initializeApp') {
       return {
         'name': call.arguments['appName'],
         'options': call.arguments['options'],

--- a/packages/firebase_storage/example/lib/main.dart
+++ b/packages/firebase_storage/example/lib/main.dart
@@ -30,8 +30,8 @@ void main() async {
           projectId: 'flutter-firebase-plugins',
         );
 
-  final FirebaseApp app = await FirebaseCore.instance
-      .initializeApp(name: 'test', options: firebaseOptions);
+  final FirebaseApp app =
+      await Firebase.initializeApp(name: 'test', options: firebaseOptions);
   final FirebaseStorage storage = FirebaseStorage(
       app: app, storageBucket: 'gs://flutter-firebase-plugins.appspot.com');
   runApp(MyApp(storage: storage));

--- a/packages/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/test/firebase_storage_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   group('FirebaseStorage', () {
     setUpAll(() async {
-      app = await FirebaseCore.instance.initializeApp(
+      app = await Firebase.initializeApp(
         name: 'testApp',
         options: const FirebaseOptions(
           appId: '1:1234567890:ios:42424242424242',

--- a/packages/firebase_storage/test/test_common.dart
+++ b/packages/firebase_storage/test/test_common.dart
@@ -7,8 +7,8 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
 
 void initializeMethodChannel() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  MethodChannelFirebaseCore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'FirebaseCore#initializeCore') {
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
       return [
         {
           'name': '[DEFAULT]',
@@ -22,7 +22,7 @@ void initializeMethodChannel() {
         }
       ];
     }
-    if (call.method == 'FirebaseCore#initializeApp') {
+    if (call.method == 'Firebase#initializeApp') {
       return {
         'name': call.arguments['appName'],
         'options': call.arguments['options'],


### PR DESCRIPTION
## Description

This PR reworks core to reflect what was discussed with Arthur:

- [x] Renames `FirebaseCore` -> `Firebase`
- [x] Removes the `.instance` getter on the class. `Firebase` now exposes statics. Note; the platform interface still exposes instance methods.
- [x] Updates some other class names to reflect these changes.
- [x] Updates tests & example apps to reflect changes. 

Documentation will be updated in a separate PR